### PR TITLE
Hotfix/smarter 2656

### DIFF
--- a/pycfdi_transform/sax/base33_handler.py
+++ b/pycfdi_transform/sax/base33_handler.py
@@ -2,8 +2,8 @@ from pycfdi_transform.sax.base_handler import BaseHandler
 
 
 class Base33Handler(BaseHandler):
-    def __init__(self):
-        BaseHandler.__init__(self)
+    def __init__(self,empty_char = '-'):
+        BaseHandler.__init__(self,empty_char)
     
     def transform_comprobante(self, tag, attrs):
         self._version = attrs['Version']

--- a/pycfdi_transform/sax/base_handler.py
+++ b/pycfdi_transform/sax/base_handler.py
@@ -1,62 +1,63 @@
 class BaseHandler():
-    def __init__(self):
-        self._version = '-'
-        self._serie = '-'
-        self._folio = '-'
-        self._fecha = '-'
-        self._no_certificado = '-'
-        self._subtotal = '-'
-        self._descuento = '-'
-        self._total = '-'
-        self._moneda = '-'
-        self._tipo_cambio = '-'
-        self._tipo_comprobante = '-'
-        self._metodo_pago = '-'
-        self._forma_pago = '-'
-        self._condiciones_pago = '-'
-        self._lugar_expedicion = '-'
+    def __init__(self, empty_char = ''):
+        self._empty_char = empty_char
+        self._version = self._empty_char
+        self._serie = self._empty_char
+        self._folio = self._empty_char
+        self._fecha = self._empty_char
+        self._no_certificado = self._empty_char
+        self._subtotal = self._empty_char
+        self._descuento = self._empty_char
+        self._total = self._empty_char
+        self._moneda = self._empty_char
+        self._tipo_cambio = self._empty_char
+        self._tipo_comprobante = self._empty_char
+        self._metodo_pago = self._empty_char
+        self._forma_pago = self._empty_char
+        self._condiciones_pago = self._empty_char
+        self._lugar_expedicion = self._empty_char
 
-        self._rfc_emisor = '-'
-        self._nombre_emisor = '-'
-        self._regimen_fiscal_emisor = '-'
+        self._rfc_emisor = self._empty_char
+        self._nombre_emisor = self._empty_char
+        self._regimen_fiscal_emisor = self._empty_char
 
-        self._rfc_receptor = '-'
-        self._nombre_receptor = '-'
-        self._residencia_fiscal_receptor = '-'
-        self._num_reg_id_trib_receptor = '-'
-        self._uso_cfdi_receptor = '-'
+        self._rfc_receptor = self._empty_char
+        self._nombre_receptor = self._empty_char
+        self._residencia_fiscal_receptor = self._empty_char
+        self._num_reg_id_trib_receptor = self._empty_char
+        self._uso_cfdi_receptor = self._empty_char
 
-        self._clave_prod_serv = '-'
+        self._clave_prod_serv = self._empty_char
 
-        self._iva_traslado = '-'
-        self._ieps_traslado = '-'
-        self._total_impuestos_traslado = '-'
-        self._isr_retenido = '-'
-        self._iva_retenido = '-'
-        self._ieps_retenido = '-'
-        self._total_impuestos_retenidos = '-'
-        self._total_traslados_impuestos_locales = '-'
-        self._total_retenciones_impuestos_locales = '-'
+        self._iva_traslado = self._empty_char
+        self._ieps_traslado = self._empty_char
+        self._total_impuestos_traslado = self._empty_char
+        self._isr_retenido = self._empty_char
+        self._iva_retenido = self._empty_char
+        self._ieps_retenido = self._empty_char
+        self._total_impuestos_retenidos = self._empty_char
+        self._total_traslados_impuestos_locales = self._empty_char
+        self._total_retenciones_impuestos_locales = self._empty_char
 
-        self._complementos = '-'
+        self._complementos = self._empty_char
 
         self._tfds = list()
-        self._uuid = '-'
-        self._fecha_timbrado = '-'
-        self._rfc_prov_cert = '-'
-        self._sello_cfd = '-'
+        self._uuid = self._empty_char
+        self._fecha_timbrado = self._empty_char
+        self._rfc_prov_cert = self._empty_char
+        self._sello_cfd = self._empty_char
 
-        self._addendas = '-'
+        self._addendas = self._empty_char
 
     def concatenate(self, text, to_add):
-        if (text == '' or text == '-'):
+        if (text == '' or text == self._empty_char):
             text = to_add
         else:
             text = f'{text}, {to_add}'
         return text
 
     def sum(self, value, to_add):
-        if (value == '' or value == '-'):
+        if (value == '' or value == self._empty_char):
             value = to_add
         else:
             value = str(float(value) + float(to_add))

--- a/pycfdi_transform/sax/cfdi33_handler.py
+++ b/pycfdi_transform/sax/cfdi33_handler.py
@@ -3,9 +3,9 @@ from pycfdi_transform.sax.base33_handler import Base33Handler
 
 
 class CFDI33Handler (xml.sax.ContentHandler, Base33Handler):
-    def __init__(self):
+    def __init__(self,empty_char = '-'):
         xml.sax.ContentHandler.__init__(self)
-        Base33Handler.__init__(self)
+        Base33Handler.__init__(self,empty_char)
         self._start_concept = False
         self._start_complement = False
         self._complement_profundity = 0

--- a/pycfdi_transform/t_sax_cfdi33.py
+++ b/pycfdi_transform/t_sax_cfdi33.py
@@ -4,16 +4,17 @@ from pycfdi_transform.sax.cfdi33_handler import CFDI33Handler
 
 
 class TSaxCfdi33(TSaxBase):
-    def __init__(self):
+    def __init__(self,empty_char = '-'):
         super().__init__()
         self.addendas = None
+        self._empty_char = empty_char
 
     def to_columns_from_file(self, xml_file):
         if ('.xml' in xml_file):
             try:
-                handler = CFDI33Handler()
+                handler = CFDI33Handler(self._empty_char)
                 self.parse_file(handler, xml_file)
-                self.addendas = handler.get_addendas() if not handler.get_addendas() == '-' else None
+                self.addendas = handler.get_addendas() if not handler.get_addendas() == self._empty_char or not handler.get_addendas() == '' else None
                 return handler.get_result()
             except Exception as ex:
                 print(ex)
@@ -23,7 +24,7 @@ class TSaxCfdi33(TSaxBase):
         try:
             handler = CFDI33Handler()
             self.parse_string(handler, string_xml)
-            self.addendas = handler.get_addendas() if not handler.get_addendas() == '-' else None
+            self.addendas = handler.get_addendas() if not handler.get_addendas() == self._empty_char or not handler.get_addendas() == ''  else None
             return handler.get_result()
         except Exception as ex:
             print(ex)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pycfdi_transform",
-    version="0.0.1.5",
+    version="0.0.1.6",
     author="SW sapien",
     description="Cfdi Xml Transformation column format/csv",
     long_description=long_description,

--- a/tests/test_pycfdi_sax_transform.py
+++ b/tests/test_pycfdi_sax_transform.py
@@ -136,6 +136,16 @@ class TestPycfdiSaxTransform(unittest.TestCase):
         self.assertTrue(len(result_columns[0])==38)
         self.assertTrue(transformer.has_addendas())
         self.assertTrue(transformer.get_addendas() == 'NombreAdenda, xmlAtt')
+    
+    def test_sax_cfdi33_01_from_file_ok_with_empty_char(self):
+        path_xml = './tests/Resources/cfdi33_01.xml'
+        transformer = ct.TSaxCfdi33(empty_char='#')
+        result_columns = transformer.to_columns_from_file(path_xml)
+        self.assertFalse(result_columns is None)
+        self.assertTrue(len(result_columns)==1)
+        self.assertTrue(len(result_columns[0])==38)
+        self.assertTrue(result_columns[0][1] == 'VF')
+        self.assertTrue(result_columns[0][6] == '#')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Se agrega funcionalidad para soportar de manera opcional especificar el empty_char. Anteriormente las columnas empty se inicializaban el valor con el caracter '-'. Con estos cambios se puede especificar como se inicializaran las empty cells. Este cambio solo aplica para la version TSaxCfdi33