### PR TITLE
SWSMTR-2409

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
   inputs:
     script: |
       python -m pip install --upgrade pip
-      python -m pip install --upgrade setuptools wheel build
+      python -m pip install "setuptools<58.0.0" --upgrade wheel build
       rm -rf dist build *.egg-info
       python -m build --outdir $(Build.ArtifactStagingDirectory)/dist
 - task: PublishBuildArtifacts@1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=68", "wheel", "build"]
+requires = ["setuptools<58.0.0", "wheel", "build"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
build: pin setuptools to version below 58.0.0

Update pyproject.toml and CI script to restrict setuptools to versions before 58.0.0 to maintain compatibility with the current build process.